### PR TITLE
Sort delta column by absolute value

### DIFF
--- a/client/src/components/options-table/columns.tsx
+++ b/client/src/components/options-table/columns.tsx
@@ -115,7 +115,7 @@ export const columns: ColumnDef<OptionChainRow>[] = [
 
       return <div className={cn('p-2 text-center font-medium', deltaColor)}>{(delta * 100).toFixed(7)}</div>;
     },
-    sortingFn: (rowA, rowB) => rowA.original.delta - rowB.original.delta,
+    sortingFn: (rowA, rowB) => Math.abs(rowA.original.delta) - Math.abs(rowB.original.delta),
   },
   {
     id: 'sigmaXI',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Delta (Δ) column sorting in the options table to use absolute values instead of raw signed values.

- **Ascending**: smallest `|delta|` rows appear first
- **Descending**: largest `|delta|` rows appear first

This treats +0.05 and -0.05 as equivalent for sort order.

## Test plan

- [ ] Load the option chain table
- [ ] Click the Delta column header to sort ascending — verify rows with deltas closest to zero (positive or negative) appear at the top
- [ ] Click again for descending — verify rows with the largest absolute deltas appear at the top

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f14e1-395a-747c-9593-2db0db4fbd69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f14e1-395a-747c-9593-2db0db4fbd69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

