### PR TITLE
Fix sigma xi row calculation to ignore SD multiplier

### DIFF
--- a/server/lib/services/option-chain-coordinator.ts
+++ b/server/lib/services/option-chain-coordinator.ts
@@ -326,7 +326,8 @@ export class OptionChainCoordinator {
       if (row.av > 0) {
         const workingDaysTillExpiry = await workingDaysCache.getWorkingDaysTillExpiry(row.expiry);
         const sigma = calculateSd(row.av, workingDaysInLastYear, workingDaysTillExpiry);
-        const sigmaN = calculateSigmaN(sigma, this.filter?.sdMultiplier ?? 1);
+        // SD multiplier applies only to strike-selection bounds, not per-row sigma display.
+        const sigmaN = calculateSigmaN(sigma, 1);
         const sigmaX = calculateSigmaX(sigmaN, workingDaysInLastYear, workingDaysTillExpiry);
         const sigmaXI = calculateSigmaXi(sigmaN, sigmaX, row.instrumentType);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After the Kite/Hono migration, changing the **SD Multiplier** filter incorrectly scaled the **σₓᵢ %** column for every option row. The multiplier is meant to widen or narrow which strikes get subscribed — not to change the per-row sigma values shown in the table.

## Root cause

In `option-chain-coordinator.ts` → `recomputeRows()`, row-level sigma was computed with:

```ts
calculateSigmaN(sigma, this.filter?.sdMultiplier ?? 1)
```

That propagated the user multiplier into `sigmaN`, `sigmaX`, and `sigmaXI` for every row.

## Legacy behavior (commit `cafd283`)

Compared against the pre-migration codebase:

| Location | SD multiplier usage |
|----------|---------------------|
| `src/pages/api/stockInit.ts` | Uses user `sdMultiplier` for **asymmetric bounds** (which strikes to monitor) |
| `src/lib/socket.ts` | Uses hardcoded **`1`** for per-instrument `calculateAllSigmas()` (table display) |

The new `subscription-planner.ts` already matches `stockInit.ts` (multiplier applied at bounds level). Only the coordinator row recompute was wrong.

## Fix

Use multiplier `1` when computing per-row sigmas in `recomputeRows()`, with a comment explaining that the filter multiplier applies only to strike selection.

## Verification

- `npm run typecheck` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f14fb-f754-7906-b98b-8f71f757aecd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f14fb-f754-7906-b98b-8f71f757aecd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

