### PR TITLE
Include today's expiry in chain expiry dropdown

### DIFF
--- a/server/lib/services/instrument-catalog.ts
+++ b/server/lib/services/instrument-catalog.ts
@@ -1,7 +1,11 @@
+import { TZDate } from '@date-fns/tz';
 import { db } from '@server/db';
 import type { instrumentsTable as instrumentsTableType } from '@server/db/schema';
 import { instrumentsTable } from '@server/db/schema';
-import { and, asc, eq, gt, inArray, sql } from 'drizzle-orm';
+import { format } from 'date-fns';
+import { and, asc, eq, gte, inArray, sql } from 'drizzle-orm';
+
+const INDIA_TIMEZONE = 'Asia/Kolkata';
 
 export type DbInstrument = typeof instrumentsTableType.$inferSelect;
 
@@ -65,7 +69,7 @@ export const getOptionsForNameAndExpiry = async (name: string, expiry: string) =
 };
 
 export const getUpcomingOptionExpiries = async (limit = 3) => {
-  const today = new Date().toISOString().split('T')[0]!;
+  const today = format(new TZDate(Date.now(), INDIA_TIMEZONE), 'yyyy-MM-dd');
   const rows = await db
     .selectDistinct({ expiry: instrumentsTable.expiry })
     .from(instrumentsTable)
@@ -73,7 +77,7 @@ export const getUpcomingOptionExpiries = async (limit = 3) => {
       and(
         eq(instrumentsTable.exchange, 'NFO'),
         inArray(instrumentsTable.instrumentType, ['CE', 'PE']),
-        gt(instrumentsTable.expiry, today)
+        gte(instrumentsTable.expiry, today)
       )
     )
     .orderBy(asc(instrumentsTable.expiry))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Include today's expiry date in the chain filter dropdown on expiry day by changing the DB filter from `gt` (strictly after today) to `gte` (today or later).
- Use IST (`Asia/Kolkata`) for the "today" comparison so it stays aligned with working-days and ban-date logic.
- Fix the seed script to keep NFO instruments expiring today (`i.expiry > new Date()` was excluding them once the clock passed midnight) and store expiry dates in IST instead of UTC `toISOString`.

## Context

Previously, both the expiry API and seed script excluded the current expiry date. On expiry day the dropdown would skip to the next expiry, and re-seeding would drop today's option contracts from the database. Calculations are already safe for expiry day (`workingDaysTillExpiry` floors at 1).

## Test plan

- [ ] On an expiry day (or by temporarily mocking `today`), verify `/api/chain/expiries` returns today's date as the first option.
- [ ] Run `npm run db:seed` on expiry day and confirm today's NFO CE/PE contracts are present in `instruments`.
- [ ] Confirm the chain filter form auto-selects today's expiry and loads the chain successfully.
- [ ] Verify future expiries still appear after today in ascending order.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f16dd-86a6-7dc9-8a5d-05e5ee215af0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f16dd-86a6-7dc9-8a5d-05e5ee215af0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

