### PR TITLE
Remove orderPercent field and order-trigger notifications

### DIFF
--- a/client/src/components/chain-filter-form.tsx
+++ b/client/src/components/chain-filter-form.tsx
@@ -19,7 +19,7 @@ type FilterForm = z.infer<typeof chainFilterSchema>;
 
 export function ChainFilterForm() {
   const queryClient = useQueryClient();
-  const { chainStatus, setEntryValue, setOrderPercent, applyOptionChainData } = useWebSocketContext();
+  const { chainStatus, setEntryValue, applyOptionChainData } = useWebSocketContext();
   const { data: expiriesData } = useChainExpiries();
   const expiries = expiriesData?.expiries ?? [];
 
@@ -28,21 +28,15 @@ export function ChainFilterForm() {
     defaultValues: {
       expiry: '',
       entryValue: 99,
-      orderPercent: 0.5,
       sdMultiplier: 1,
     },
   });
 
   const watchedEntryValue = form.watch('entryValue');
-  const watchedOrderPercent = form.watch('orderPercent');
 
   useEffect(() => {
     setEntryValue(watchedEntryValue);
   }, [setEntryValue, watchedEntryValue]);
-
-  useEffect(() => {
-    setOrderPercent(watchedOrderPercent);
-  }, [setOrderPercent, watchedOrderPercent]);
 
   useEffect(() => {
     if (expiries[0] && !form.getValues('expiry')) {
@@ -61,7 +55,6 @@ export function ChainFilterForm() {
     },
     onSuccess: (result, values) => {
       setEntryValue(values.entryValue);
-      setOrderPercent(values.orderPercent);
       applyOptionChainData(result.data);
       void queryClient.invalidateQueries({ queryKey: queryKeys.chain.status });
       toast.success(
@@ -83,7 +76,7 @@ export function ChainFilterForm() {
   const selectedExpiry = form.watch('expiry') || expiries[0] || '';
 
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)} className='grid gap-8 p-4 md:grid-cols-5'>
+    <form onSubmit={form.handleSubmit(onSubmit)} className='grid gap-8 p-4 md:grid-cols-4'>
       <div className='space-y-2'>
         <Label htmlFor='expiry'>Expiry</Label>
         <Select value={selectedExpiry} onValueChange={(value) => form.setValue('expiry', value!)}>
@@ -103,16 +96,6 @@ export function ChainFilterForm() {
       <div className='space-y-2'>
         <Label htmlFor='entryValue'>Entry Value</Label>
         <Input id='entryValue' type='number' step='0.05' {...form.register('entryValue', { valueAsNumber: true })} />
-      </div>
-
-      <div className='space-y-2'>
-        <Label htmlFor='orderPercent'>Order %</Label>
-        <Input
-          id='orderPercent'
-          type='number'
-          step='0.01'
-          {...form.register('orderPercent', { valueAsNumber: true })}
-        />
       </div>
 
       <div className='space-y-2'>

--- a/client/src/components/options-table/columns.tsx
+++ b/client/src/components/options-table/columns.tsx
@@ -7,6 +7,20 @@ import { RowOrderAction } from './order-action';
 const green = 'bg-emerald-50/60 text-emerald-800 ring-emerald-100 dark:bg-emerald-900/10 dark:text-emerald-500';
 const red = 'bg-red-50/60 text-red-800 ring-red-100 dark:bg-red-900/10 dark:text-red-500';
 
+export const DEFAULT_DELTA_FILTER = 5;
+
+const deltaColumnFilterFn: ColumnDef<OptionChainRow>['filterFn'] = (row, _columnId, filterValue) => {
+  const threshold =
+    typeof filterValue === 'number' && !Number.isNaN(filterValue) ? filterValue : DEFAULT_DELTA_FILTER;
+  const { delta } = row.original;
+
+  if (delta == null || Number.isNaN(delta)) {
+    return false;
+  }
+
+  return Math.abs(delta * 100) < threshold;
+};
+
 export const columns: ColumnDef<OptionChainRow>[] = [
   {
     id: 'optionStrike',
@@ -98,6 +112,7 @@ export const columns: ColumnDef<OptionChainRow>[] = [
   {
     id: 'delta',
     accessorKey: 'delta',
+    filterFn: deltaColumnFilterFn,
     header: ({ column }) => <DataTableColumnHeader column={column} title='Delta (Δ)' />,
     cell: ({ row }) => {
       const { delta } = row.original;

--- a/client/src/components/options-table/data-table.tsx
+++ b/client/src/components/options-table/data-table.tsx
@@ -12,7 +12,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { memo, useState } from 'react';
-import { columns, fillHeightCols, numericCols } from './columns';
+import { columns, DEFAULT_DELTA_FILTER, fillHeightCols, numericCols } from './columns';
 import { DataTableToolbar } from './toolbar';
 
 interface DataTableProps {
@@ -23,7 +23,9 @@ interface DataTableProps {
 
 export const DataTable = memo(function DataTable({ data, emptyMessage, summaryText }: DataTableProps) {
   const [sorting, setSorting] = useState<SortingState>([{ id: 'returnValue', desc: true }]);
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([
+    { id: 'delta', value: DEFAULT_DELTA_FILTER },
+  ]);
 
   const table = useReactTable({
     data,

--- a/client/src/components/options-table/toolbar.tsx
+++ b/client/src/components/options-table/toolbar.tsx
@@ -1,7 +1,9 @@
 import { Button } from '@client/components/ui/button';
 import { Input } from '@client/components/ui/input';
+import { Label } from '@client/components/ui/label';
 import type { Table } from '@tanstack/react-table';
 import { X } from 'lucide-react';
+import { DEFAULT_DELTA_FILTER } from './columns';
 
 interface DataTableToolbarProps<TData> {
   table: Table<TData>;
@@ -9,10 +11,30 @@ interface DataTableToolbarProps<TData> {
 }
 
 export function DataTableToolbar<TData>({ table, summaryText }: DataTableToolbarProps<TData>) {
-  const isFiltered = table.getPreFilteredRowModel().rows.length > table.getFilteredRowModel().rows.length;
+  const searchValue = (table.getColumn('optionStrike')?.getFilterValue() as string) ?? '';
+  const deltaFilterValue = (table.getColumn('delta')?.getFilterValue() as number | undefined) ?? DEFAULT_DELTA_FILTER;
+  const isFiltered = Boolean(searchValue) || deltaFilterValue !== DEFAULT_DELTA_FILTER;
 
   const onSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     table.getColumn('optionStrike')?.setFilterValue(event.target.value);
+  };
+
+  const onDeltaChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = event.target.value;
+    if (raw === '') {
+      table.getColumn('delta')?.setFilterValue(DEFAULT_DELTA_FILTER);
+      return;
+    }
+
+    const value = Number.parseFloat(raw);
+    if (!Number.isNaN(value)) {
+      table.getColumn('delta')?.setFilterValue(value);
+    }
+  };
+
+  const resetFilters = () => {
+    table.getColumn('optionStrike')?.setFilterValue('');
+    table.getColumn('delta')?.setFilterValue(DEFAULT_DELTA_FILTER);
   };
 
   return (
@@ -20,12 +42,25 @@ export function DataTableToolbar<TData>({ table, summaryText }: DataTableToolbar
       <div className='flex items-center gap-2'>
         <Input
           placeholder='Search options...'
-          value={(table.getColumn('optionStrike')?.getFilterValue() as string) ?? ''}
+          value={searchValue}
           onChange={onSearchChange}
           className='max-w-sm'
         />
+        <div className='flex items-center gap-2'>
+          <Label htmlFor='deltaFilter' className='shrink-0'>
+            Delta
+          </Label>
+          <Input
+            id='deltaFilter'
+            type='number'
+            step='0.001'
+            value={deltaFilterValue}
+            onChange={onDeltaChange}
+            className='w-24'
+          />
+        </div>
         {isFiltered ? (
-          <Button variant='ghost' onClick={() => table.resetColumnFilters()} className='h-8 px-2 lg:px-3'>
+          <Button variant='ghost' onClick={resetFilters} className='h-8 px-2 lg:px-3'>
             Reset
             <X className='ml-2 h-4 w-4' />
           </Button>

--- a/client/src/contexts/websocket-context.tsx
+++ b/client/src/contexts/websocket-context.tsx
@@ -11,8 +11,6 @@ interface WebSocketContextType {
   visibleRowCount: number;
   entryValue: number;
   setEntryValue: (value: number) => void;
-  orderPercent: number;
-  setOrderPercent: (value: number) => void;
   applyOptionChainData: (data: OptionChainData) => void;
   isConnected: boolean;
   connect: () => void;
@@ -23,7 +21,6 @@ interface WebSocketContextType {
     expiry: string;
     sdMultiplier: number;
     entryValue: number;
-    orderPercent: number;
     symbols?: string[];
   }) => void;
   updateSdMultiplier: (value: number) => void;

--- a/client/src/hooks/use-websocket.ts
+++ b/client/src/hooks/use-websocket.ts
@@ -16,7 +16,6 @@ export function useWebSocket({ subscribedSymbols, onNotification }: UseWebSocket
   const [rowCount, setRowCount] = useState(0);
   const [visibleRowCount, setVisibleRowCount] = useState(0);
   const [entryValue, setEntryValue] = useState(99);
-  const [orderPercent, setOrderPercent] = useState(0.5);
   const [isConnected, setIsConnected] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimeoutRef = useRef<number | null>(null);
@@ -74,7 +73,7 @@ export function useWebSocket({ subscribedSymbols, onNotification }: UseWebSocket
           if (message.type === 'notification') {
             onNotificationRef.current?.(message.message, message.severity);
             if (message.severity === 'important') {
-              toast(message.message.includes('order trigger') ? 'Order Triggered!' : 'Alert', {
+              toast('Alert', {
                 description: message.message,
               });
             }
@@ -168,7 +167,6 @@ export function useWebSocket({ subscribedSymbols, onNotification }: UseWebSocket
       expiry: string;
       sdMultiplier: number;
       entryValue: number;
-      orderPercent: number;
       symbols?: string[];
     }) => {
       if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
@@ -200,8 +198,6 @@ export function useWebSocket({ subscribedSymbols, onNotification }: UseWebSocket
     visibleRowCount,
     entryValue,
     setEntryValue,
-    orderPercent,
-    setOrderPercent,
     applyOptionChainData,
     isConnected,
     connect,

--- a/server/lib/calculators/returns.ts
+++ b/server/lib/calculators/returns.ts
@@ -10,6 +10,3 @@ export const calculateReturnValue = (sellValue: number, orderMargin: number) => 
   }
   return (sellValue * 100) / orderMargin;
 };
-
-export const shouldTriggerOrder = (returnValue: number, orderPercent: number, marginStatus: string) =>
-  returnValue >= orderPercent && marginStatus === 'ready';

--- a/server/lib/services/option-chain-coordinator.ts
+++ b/server/lib/services/option-chain-coordinator.ts
@@ -3,7 +3,6 @@ import {
   calculateReturnValue,
   calculateSellValue,
   calculateStrikePosition,
-  shouldTriggerOrder,
 } from '@server/lib/calculators/returns';
 import { calculateSd, calculateSigmaN, calculateSigmaX, calculateSigmaXi } from '@server/lib/calculators/sigma';
 import { logger } from '@server/lib/logger';
@@ -55,9 +54,6 @@ export class OptionChainCoordinator {
   private computeTimer: ReturnType<typeof setInterval> | null = null;
   private marginTimer: ReturnType<typeof setInterval> | null = null;
   private tickUnsubscribe: (() => void) | null = null;
-  private triggeredOrderTokens = new Set<number>();
-  private baselineTokens = new Set<number>();
-  private loadingAtPrime = new Set<number>();
   private alertsPrimed = false;
   private topBidToken: number | null = null;
   private topBidValue: number | null = null;
@@ -122,7 +118,6 @@ export class OptionChainCoordinator {
             expiry: this.filter.expiry,
             sdMultiplier: this.filter.sdMultiplier,
             entryValue: this.filter.entryValue,
-            orderPercent: this.filter.orderPercent,
           }
         : null,
       subscribedTokenCount: marketDataService.getSubscribedTokens().size,
@@ -383,9 +378,6 @@ export class OptionChainCoordinator {
   }
 
   private resetAlertState() {
-    this.triggeredOrderTokens.clear();
-    this.baselineTokens.clear();
-    this.loadingAtPrime.clear();
     this.alertsPrimed = false;
     this.topBidToken = null;
     this.topBidValue = null;
@@ -404,71 +396,24 @@ export class OptionChainCoordinator {
     return topRow;
   }
 
-  private formatOrderTriggerMessage(rows: InternalRow[]): string {
-    if (rows.length === 1) {
-      const row = rows[0]!;
-      return `Order triggered for ${row.tradingsymbol} — return ${row.returnValue.toFixed(2)}, bid ${row.bid}, qty ${row.lotSize}`;
-    }
-
-    const preview = rows
-      .slice(0, 3)
-      .map((row) => row.tradingsymbol)
-      .join(', ');
-    const remaining = rows.length - 3;
-    const suffix = remaining > 0 ? ` (+${remaining} more)` : '';
-    return `${rows.length} new order triggers: ${preview}${suffix}`;
-  }
-
   private detectAlerts() {
     if (!this.filter || this.rows.size === 0) {
       return;
     }
 
-    const orderPercent = this.filter.orderPercent;
+    const topRow = this.getTopReturnRow();
+    if (!topRow) {
+      return;
+    }
 
     if (!this.alertsPrimed) {
-      for (const row of this.rows.values()) {
-        this.baselineTokens.add(row.instrumentToken);
-        if (row.marginStatus === 'loading') {
-          this.loadingAtPrime.add(row.instrumentToken);
-        }
-        if (shouldTriggerOrder(row.returnValue, orderPercent, row.marginStatus)) {
-          this.triggeredOrderTokens.add(row.instrumentToken);
-        }
-      }
-
-      const topRow = this.getTopReturnRow();
-      if (topRow) {
-        this.topBidToken = topRow.instrumentToken;
-        this.topBidValue = topRow.bid;
-      }
-
+      this.topBidToken = topRow.instrumentToken;
+      this.topBidValue = topRow.bid;
       this.alertsPrimed = true;
       return;
     }
 
-    const newlyTriggered: InternalRow[] = [];
-
-    for (const row of this.rows.values()) {
-      if (this.triggeredOrderTokens.has(row.instrumentToken)) {
-        continue;
-      }
-      if (!shouldTriggerOrder(row.returnValue, orderPercent, row.marginStatus)) {
-        continue;
-      }
-
-      this.triggeredOrderTokens.add(row.instrumentToken);
-      if (!this.loadingAtPrime.has(row.instrumentToken)) {
-        newlyTriggered.push(row);
-      }
-    }
-
-    if (newlyTriggered.length > 0) {
-      this.notificationHandler?.(this.formatOrderTriggerMessage(newlyTriggered), 'important');
-    }
-
-    const topRow = this.getTopReturnRow();
-    if (topRow && this.topBidToken === topRow.instrumentToken && this.topBidValue !== null) {
+    if (this.topBidToken === topRow.instrumentToken && this.topBidValue !== null) {
       if (topRow.bid !== this.topBidValue) {
         this.notificationHandler?.(
           `Top bid changed for ${topRow.tradingsymbol}: ${this.topBidValue.toFixed(2)} → ${topRow.bid.toFixed(2)}`,
@@ -477,10 +422,8 @@ export class OptionChainCoordinator {
       }
     }
 
-    if (topRow) {
-      this.topBidToken = topRow.instrumentToken;
-      this.topBidValue = topRow.bid;
-    }
+    this.topBidToken = topRow.instrumentToken;
+    this.topBidValue = topRow.bid;
   }
 
   async shutdown() {

--- a/server/shared/schemas/chain-filter.ts
+++ b/server/shared/schemas/chain-filter.ts
@@ -4,7 +4,6 @@ export const chainFilterSchema = z.object({
   expiry: z.string().min(1),
   sdMultiplier: z.number().min(0).max(10),
   entryValue: z.number().min(0),
-  orderPercent: z.number().min(0).max(100),
   symbols: z.array(z.string()).optional(),
 });
 

--- a/server/shared/schemas/websocket.ts
+++ b/server/shared/schemas/websocket.ts
@@ -16,7 +16,6 @@ export const wsUpdateFilterSchema = z.object({
     expiry: z.string(),
     sdMultiplier: z.number(),
     entryValue: z.number(),
-    orderPercent: z.number(),
     symbols: z.array(z.string()).optional(),
   }),
 });

--- a/server/shared/types/types.ts
+++ b/server/shared/types/types.ts
@@ -51,7 +51,6 @@ export type ChainEngineStatus = {
     expiry: string;
     sdMultiplier: number;
     entryValue: number;
-    orderPercent: number;
   } | null;
   subscribedTokenCount: number;
   rowCount: number;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the **Order %** (`orderPercent`) field and all related order-trigger notification logic. Adds a client-side **Delta** table filter beside search.

## Changes

### Order % removal
- **UI**: Removed Order % input from the chain filter form (grid now 4 columns: expiry, entry value, SD multiplier, apply button).
- **Schemas/types**: Dropped `orderPercent` from `chainFilterSchema`, websocket `updateFilter`, and `ChainEngineStatus`.
- **Server**: Removed `shouldTriggerOrder()` and order-trigger alert detection from the coordinator.
- **Client**: Removed unused `orderPercent` websocket state; simplified important-alert toast.

### Delta table filter (new)
- **Toolbar**: Delta numeric input beside search (default `5`, step `0.001`).
- **Filter logic**: Client-side only — shows rows where `|delta × 100| < threshold` (matches displayed delta %). Example: threshold `5` keeps rows with delta strictly between `-5` and `+5` on the displayed scale.
- **Reset**: Clears search and restores delta to `5`.

## Unchanged

- **Top-bid-change** notifications still fire when the highest-return row's bid changes.
- Entry value filtering, sell-order button threshold (`returnValue > 0.05`), and server chain pipeline are unchanged.

## Testing

- `npm run typecheck` (server)
- `cd client && npm run typecheck` (client)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f215a-f092-7c0e-857c-2910b9b5411f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f215a-f092-7c0e-857c-2910b9b5411f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

