### PR TITLE
Replace bid alerts with client-side top-3 delta sound

### DIFF
--- a/client/src/contexts/websocket-context.tsx
+++ b/client/src/contexts/websocket-context.tsx
@@ -1,5 +1,5 @@
 import { useWebSocket } from '@client/hooks/use-websocket';
-import { useNotifications } from '@client/contexts/notification-context';
+import { useTopDeltaSound } from '@client/hooks/use-top-delta-sound';
 import type { ChainEngineStatus, OptionChainData } from '@shared/types/types';
 import { createContext, useContext, type ReactNode } from 'react';
 
@@ -42,8 +42,8 @@ interface WebSocketProviderProps {
 }
 
 export function WebSocketProvider({ children, symbols }: WebSocketProviderProps) {
-  const { addNotification } = useNotifications();
-  const webSocketData = useWebSocket({ subscribedSymbols: symbols, onNotification: addNotification });
+  const webSocketData = useWebSocket({ subscribedSymbols: symbols });
+  useTopDeltaSound(webSocketData.optionChainData, webSocketData.chainStatus);
 
   return <WebSocketContext.Provider value={webSocketData}>{children}</WebSocketContext.Provider>;
 }

--- a/client/src/hooks/use-top-delta-sound.ts
+++ b/client/src/hooks/use-top-delta-sound.ts
@@ -1,0 +1,40 @@
+import { playNotificationSound } from '@client/lib/notification-sound';
+import { getTop3DeltaSet, hasTop3DeltaChanged } from '@client/lib/top-delta';
+import type { ChainEngineStatus, OptionChainData } from '@shared/types/types';
+import { useEffect, useRef } from 'react';
+
+export function useTopDeltaSound(
+  optionChainData: OptionChainData,
+  chainStatus: ChainEngineStatus['status']
+) {
+  const previousTop3Ref = useRef<Set<number> | null>(null);
+  const primedRef = useRef(false);
+
+  useEffect(() => {
+    if (chainStatus !== 'ready') {
+      primedRef.current = false;
+      previousTop3Ref.current = null;
+    }
+  }, [chainStatus]);
+
+  useEffect(() => {
+    if (chainStatus !== 'ready') {
+      return;
+    }
+
+    const nextTop3 = getTop3DeltaSet(optionChainData);
+
+    if (!primedRef.current) {
+      previousTop3Ref.current = nextTop3;
+      primedRef.current = true;
+      return;
+    }
+
+    const previousTop3 = previousTop3Ref.current;
+    if (previousTop3 && hasTop3DeltaChanged(previousTop3, nextTop3)) {
+      playNotificationSound();
+    }
+
+    previousTop3Ref.current = nextTop3;
+  }, [optionChainData, chainStatus]);
+}

--- a/client/src/hooks/use-websocket.ts
+++ b/client/src/hooks/use-websocket.ts
@@ -1,4 +1,3 @@
-import type { NotificationType } from '@client/contexts/notification-context';
 import type { WsServerMessage } from '@server/shared/schemas/websocket';
 import type { ChainEngineStatus, OptionChainData } from '@shared/types/types';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -6,10 +5,9 @@ import { toast } from 'sonner';
 
 interface UseWebSocketOptions {
   subscribedSymbols?: string[];
-  onNotification?: (message: string, type: NotificationType) => void;
 }
 
-export function useWebSocket({ subscribedSymbols, onNotification }: UseWebSocketOptions = {}) {
+export function useWebSocket({ subscribedSymbols }: UseWebSocketOptions = {}) {
   const [optionChainData, setOptionChainData] = useState<OptionChainData>({});
   const [chainStatus, setChainStatus] = useState<ChainEngineStatus['status']>('idle');
   const [statusMessage, setStatusMessage] = useState<string | undefined>();
@@ -22,11 +20,6 @@ export function useWebSocket({ subscribedSymbols, onNotification }: UseWebSocket
   const reconnectAttemptsRef = useRef(0);
   const subscribedSymbolsRef = useRef<string[]>(subscribedSymbols ?? []);
   const pendingSubscriptionsRef = useRef<string[]>([]);
-  const onNotificationRef = useRef(onNotification);
-
-  useEffect(() => {
-    onNotificationRef.current = onNotification;
-  }, [onNotification]);
 
   const connect = useCallback(() => {
     try {
@@ -67,15 +60,6 @@ export function useWebSocket({ subscribedSymbols, onNotification }: UseWebSocket
             }
             if (message.visibleRowCount !== undefined) {
               setVisibleRowCount(message.visibleRowCount);
-            }
-          }
-
-          if (message.type === 'notification') {
-            onNotificationRef.current?.(message.message, message.severity);
-            if (message.severity === 'important') {
-              toast('Alert', {
-                description: message.message,
-              });
             }
           }
         } catch (error) {

--- a/client/src/lib/top-delta.ts
+++ b/client/src/lib/top-delta.ts
@@ -1,0 +1,27 @@
+import type { OptionChainData, OptionChainRow } from '@shared/types/types';
+
+export function getTop3DeltaTokens(rows: OptionChainRow[]): number[] {
+  return [...rows]
+    .filter((row) => row.av > 0)
+    .sort((a, b) => Math.abs(a.delta) - Math.abs(b.delta))
+    .slice(0, 3)
+    .map((row) => row.instrumentToken);
+}
+
+export function getTop3DeltaSet(data: OptionChainData): Set<number> {
+  return new Set(getTop3DeltaTokens(Object.values(data)));
+}
+
+export function hasTop3DeltaChanged(previous: Set<number>, next: Set<number>): boolean {
+  if (previous.size !== next.size) {
+    return true;
+  }
+
+  for (const token of next) {
+    if (!previous.has(token)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1274,6 +1274,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1290,6 +1291,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1306,6 +1308,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1322,6 +1325,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1338,6 +1342,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1354,6 +1359,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1370,6 +1376,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1386,6 +1393,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1402,6 +1410,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1418,6 +1427,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1434,6 +1444,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1450,6 +1461,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1466,6 +1478,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1482,6 +1495,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1498,6 +1512,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1514,6 +1529,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1530,6 +1546,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1546,6 +1563,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1562,6 +1580,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1578,6 +1597,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1594,6 +1614,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1610,6 +1631,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1626,6 +1648,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1642,6 +1665,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1658,6 +1682,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1674,6 +1699,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2287,9 +2313,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2307,9 +2330,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2327,9 +2347,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2347,9 +2364,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2367,9 +2381,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2387,9 +2398,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2407,9 +2415,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2427,9 +2432,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2519,6 +2521,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2535,6 +2538,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2551,6 +2555,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2567,6 +2572,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2583,6 +2589,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2594,14 +2601,12 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2613,14 +2618,12 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2632,14 +2635,12 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2651,14 +2652,12 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2670,14 +2669,12 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2689,14 +2686,12 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2713,6 +2708,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2726,6 +2722,7 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.11.1",
         "@emnapi/runtime": "1.11.1",
@@ -2747,6 +2744,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2763,6 +2761,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2931,9 +2930,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2949,9 +2945,6 @@
       "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2969,9 +2962,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2987,9 +2977,6 @@
       "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6254,9 +6241,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6276,9 +6260,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -6300,9 +6281,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6322,9 +6300,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/server/app.ts
+++ b/server/app.ts
@@ -34,10 +34,6 @@ optionChainCoordinator.onUpdate((data, status) => {
   clientBroadcaster.publishOptionChain(data, status);
 });
 
-optionChainCoordinator.onNotification((message, severity) => {
-  clientBroadcaster.publishNotification(message, severity);
-});
-
 const apiRoutes = app
   .basePath('/api')
   .route('/user', userRoute)

--- a/server/lib/services/option-chain-coordinator.ts
+++ b/server/lib/services/option-chain-coordinator.ts
@@ -28,7 +28,6 @@ import type { ChainEngineStatus, OptionChainData, OptionChainRow } from '@shared
 import type { TickFull } from 'kiteconnect-ts';
 
 type ChainUpdateHandler = (data: OptionChainData, status: ChainEngineStatus) => void;
-type NotificationHandler = (message: string, severity: 'info' | 'important') => void;
 
 type InternalRow = OptionChainRow & {
   futExpiry: string;
@@ -50,13 +49,9 @@ export class OptionChainCoordinator {
   private status: ChainEngineStatus['status'] = 'idle';
   private statusMessage?: string;
   private updateHandler: ChainUpdateHandler | null = null;
-  private notificationHandler: NotificationHandler | null = null;
   private computeTimer: ReturnType<typeof setInterval> | null = null;
   private marginTimer: ReturnType<typeof setInterval> | null = null;
   private tickUnsubscribe: (() => void) | null = null;
-  private alertsPrimed = false;
-  private topBidToken: number | null = null;
-  private topBidValue: number | null = null;
 
   async init() {
     await workingDaysCache.initializeRuntimeCache();
@@ -105,10 +100,6 @@ export class OptionChainCoordinator {
     this.updateHandler = handler;
   }
 
-  onNotification(handler: NotificationHandler) {
-    this.notificationHandler = handler;
-  }
-
   getStatus(): ChainEngineStatus {
     return {
       status: this.status,
@@ -128,7 +119,6 @@ export class OptionChainCoordinator {
   }
 
   async applyFilter(filter: ChainFilter) {
-    this.resetAlertState();
     this.filter = filter;
     this.setStatus('warming', 'Applying filter');
 
@@ -243,7 +233,6 @@ export class OptionChainCoordinator {
     this.recomputeRows();
 
     this.setStatus('ready');
-    this.detectAlerts();
   }
 
   async updateSdMultiplier(value: number) {
@@ -351,9 +340,6 @@ export class OptionChainCoordinator {
       }
     }
 
-    if (this.status === 'ready') {
-      this.detectAlerts();
-    }
   }
 
   private async refreshMargins() {
@@ -375,55 +361,6 @@ export class OptionChainCoordinator {
 
   private publish() {
     this.updateHandler?.(this.getSnapshot(), this.getStatus());
-  }
-
-  private resetAlertState() {
-    this.alertsPrimed = false;
-    this.topBidToken = null;
-    this.topBidValue = null;
-  }
-
-  private getTopReturnRow(): InternalRow | null {
-    let topRow: InternalRow | null = null;
-    for (const row of this.rows.values()) {
-      if (row.marginStatus !== 'ready') {
-        continue;
-      }
-      if (!topRow || row.returnValue > topRow.returnValue) {
-        topRow = row;
-      }
-    }
-    return topRow;
-  }
-
-  private detectAlerts() {
-    if (!this.filter || this.rows.size === 0) {
-      return;
-    }
-
-    const topRow = this.getTopReturnRow();
-    if (!topRow) {
-      return;
-    }
-
-    if (!this.alertsPrimed) {
-      this.topBidToken = topRow.instrumentToken;
-      this.topBidValue = topRow.bid;
-      this.alertsPrimed = true;
-      return;
-    }
-
-    if (this.topBidToken === topRow.instrumentToken && this.topBidValue !== null) {
-      if (topRow.bid !== this.topBidValue) {
-        this.notificationHandler?.(
-          `Top bid changed for ${topRow.tradingsymbol}: ${this.topBidValue.toFixed(2)} → ${topRow.bid.toFixed(2)}`,
-          'important'
-        );
-      }
-    }
-
-    this.topBidToken = topRow.instrumentToken;
-    this.topBidValue = topRow.bid;
   }
 
   async shutdown() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reworks notifications per product request:

- **Removed** server-side `detectAlerts` (top bid change) and WebSocket `notification` publishing
- **Added** client-side tracking of the 3 rows with the lowest `|delta|` among rows where `av > 0`
- **Plays sound** when the top-3 set changes (a row enters or leaves); reordering within the top 3 does not trigger
- **Priming pass** on first `ready` snapshot after filter load — no sound until baseline is set
- **Notification tray** UI kept intact but no longer fed from the server

## Implementation

- `client/src/lib/top-delta.ts` — pure helpers for ranking and set comparison
- `client/src/hooks/use-top-delta-sound.ts` — watches `optionChainData` + `chainStatus`, calls `playNotificationSound()`
- Wired in `WebSocketProvider`; disconnected `onNotification` from websocket hook

## Test plan

- [ ] Apply a filter and confirm no sound on initial load
- [ ] When live deltas shift enough that a new instrument enters the top-3 lowest-|delta| set, confirm one sound plays
- [ ] Confirm reordering within the same top-3 set does not play sound
- [ ] Confirm notification bell/tray still renders but stays empty during normal use
- [ ] Reapply filter and confirm priming resets (no sound until next real change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f21b7-648a-7261-9575-a25ce6a92d1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f21b7-648a-7261-9575-a25ce6a92d1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

