### PR TITLE
Add calculator unit tests and GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-and-typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck server
+        run: npm run typecheck
+
+      - name: Typecheck client
+        run: npm --prefix client run typecheck
+
+      - name: Run tests
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
         "prettier-plugin-organize-imports": "^4.3.0",
         "prettier-plugin-tailwindcss": "^0.8.0",
         "tsx": "^4.22.4",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.9"
       }
     },
     "client": {
@@ -2758,6 +2759,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
@@ -3295,6 +3303,31 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "26.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
@@ -3337,6 +3370,119 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -3455,6 +3601,16 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ast-types": {
       "version": "0.16.1",
@@ -3711,6 +3867,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "5.6.2",
@@ -4941,6 +5107,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -5048,6 +5221,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -5108,6 +5291,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -6642,6 +6835,20 @@
         "node": ">= 10"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -7807,6 +8014,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -7864,6 +8078,13 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -7872,6 +8093,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -8052,6 +8280,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -8066,6 +8311,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -8487,6 +8742,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
@@ -8507,6 +8852,23 @@
       },
       "engines": {
         "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "dev:client": "npm --prefix client run dev",
     "build": "npx tsx server/scripts/build.ts",
     "start": "tsx --env-file=.env server/index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"{server,client/src}/**/*.{js,jsx,ts,tsx,css,json,md}\"",
     "db": "drizzle-kit",
@@ -48,7 +50,8 @@
     "prettier-plugin-organize-imports": "^4.3.0",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "tsx": "^4.22.4",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
   },
   "dependencies": {
     "@date-fns/tz": "^1.5.0",

--- a/server/lib/calculators/delta.test.ts
+++ b/server/lib/calculators/delta.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { calculateDelta } from '@server/lib/calculators/delta';
+
+describe('calculateDelta', () => {
+  it('returns ~0.5 for at-the-money call with moderate time value', () => {
+    const delta = calculateDelta(100, 100, 0.3, 0.25, 'CE');
+    expect(delta).toBeCloseTo(0.576, 2);
+  });
+
+  it('returns call delta minus one for puts', () => {
+    const callDelta = calculateDelta(100, 100, 0.3, 0.25, 'CE');
+    const putDelta = calculateDelta(100, 100, 0.3, 0.25, 'PE');
+    expect(putDelta).toBeCloseTo(callDelta - 1, 6);
+  });
+
+  it('approaches 1 for deep in-the-money calls', () => {
+    const delta = calculateDelta(200, 100, 0.25, 0.5, 'CE');
+    expect(delta).toBeGreaterThan(0.95);
+  });
+
+  it('approaches 0 for deep out-of-the-money calls', () => {
+    const delta = calculateDelta(50, 100, 0.25, 0.1, 'CE');
+    expect(delta).toBeLessThan(0.05);
+  });
+
+  it('returns 0 for non-positive inputs', () => {
+    expect(calculateDelta(0, 100, 0.3, 0.25, 'CE')).toBe(0);
+    expect(calculateDelta(100, 0, 0.3, 0.25, 'CE')).toBe(0);
+    expect(calculateDelta(100, 100, 0, 0.25, 'CE')).toBe(0);
+    expect(calculateDelta(100, 100, 0.3, 0, 'CE')).toBe(0);
+    expect(calculateDelta(100, 100, -0.3, 0.25, 'CE')).toBe(0);
+  });
+});

--- a/server/lib/calculators/returns.test.ts
+++ b/server/lib/calculators/returns.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calculateReturnValue,
+  calculateSellValue,
+  calculateStrikePosition,
+} from '@server/lib/calculators/returns';
+
+describe('returns calculators', () => {
+  it('subtracts bid balance and scales by lot size for sell value', () => {
+    expect(calculateSellValue(10, 50)).toBe((10 - 0.05) * 50);
+  });
+
+  it('computes strike position as percent distance from LTP', () => {
+    expect(calculateStrikePosition(110, 100)).toBe(10);
+  });
+
+  it('computes return value as sell value over margin', () => {
+    expect(calculateReturnValue(500, 10_000)).toBe(5);
+  });
+
+  it('returns 0 return when margin is non-positive', () => {
+    expect(calculateReturnValue(500, 0)).toBe(0);
+    expect(calculateReturnValue(500, -100)).toBe(0);
+  });
+});

--- a/server/lib/calculators/sigma.test.ts
+++ b/server/lib/calculators/sigma.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calculateAsymmetricBounds,
+  calculateSd,
+  calculateSigmaN,
+  calculateSigmaX,
+  calculateSigmaXi,
+} from '@server/lib/calculators/sigma';
+
+describe('sigma calculators', () => {
+  const marketMinutesInLastYear = 100_000;
+  const marketMinutesTillExpiry = 10_000;
+
+  it('scales sigma by the SD multiplier', () => {
+    expect(calculateSigmaN(2, 1.5)).toBe(3);
+  });
+
+  it('computes sigmaX from market-minute year fraction', () => {
+    const sigmaX = calculateSigmaX(2, marketMinutesInLastYear, marketMinutesTillExpiry);
+    expect(sigmaX).toBeCloseTo(2 / Math.sqrt(10), 6);
+  });
+
+  it('returns 0 for sigmaX when inputs are invalid', () => {
+    expect(calculateSigmaX(0, marketMinutesInLastYear, marketMinutesTillExpiry)).toBe(0);
+    expect(calculateSigmaX(2, 0, marketMinutesTillExpiry)).toBe(0);
+    expect(calculateSigmaX(2, marketMinutesInLastYear, 0)).toBe(0);
+  });
+
+  it('adds sigmaX for calls and subtracts for puts', () => {
+    expect(calculateSigmaXi(2, 1, 'CE')).toBe(3);
+    expect(calculateSigmaXi(2, 1, 'PE')).toBe(1);
+  });
+
+  it('returns 0 for sigmaXi when inputs are invalid', () => {
+    expect(calculateSigmaXi(0, 1, 'CE')).toBe(0);
+    expect(calculateSigmaXi(2, -1, 'CE')).toBe(0);
+  });
+
+  it('computes SD from annualized volatility and minute ratio', () => {
+    const sd = calculateSd(0.3, marketMinutesInLastYear, marketMinutesTillExpiry);
+    expect(sd).toBeCloseTo((0.3 * 100) / Math.sqrt(10), 6);
+  });
+
+  it('returns 0 for SD when minute counts are zero', () => {
+    expect(calculateSd(0.3, 0, marketMinutesTillExpiry)).toBe(0);
+    expect(calculateSd(0.3, marketMinutesInLastYear, 0)).toBe(0);
+  });
+
+  it('computes asymmetric CE/PE bounds from LTP and sigmaXi', () => {
+    const { ceBound, peBound } = calculateAsymmetricBounds(1000, 4);
+    expect(ceBound).toBe(1040);
+    expect(peBound).toBe(960);
+  });
+});

--- a/server/lib/market-minutes.test.ts
+++ b/server/lib/market-minutes.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  FULL_TRADING_DAY_MINUTES,
+  calculateMarketMinutesInRange,
+  calculateMarketMinutesTillExpiry,
+  checkDateStatus,
+  clearHolidayCacheForTests,
+  setHolidayCacheForTests,
+} from '@server/lib/market-minutes';
+
+function istInstant(isoDate: string, hour: number, minute = 0): Date {
+  const [year, month, day] = isoDate.split('-').map(Number) as [number, number, number];
+  return new Date(Date.UTC(year, month - 1, day, hour - 5, minute - 30));
+}
+
+describe('market minutes', () => {
+  beforeEach(() => {
+    clearHolidayCacheForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clearHolidayCacheForTests();
+  });
+
+  it('uses a full 375-minute NSE session', () => {
+    expect(FULL_TRADING_DAY_MINUTES).toBe(375);
+  });
+
+  it('counts only weekdays in a date range', () => {
+    const minutes = calculateMarketMinutesInRange('2026-06-29', '2026-07-03');
+    expect(minutes).toBe(5 * FULL_TRADING_DAY_MINUTES);
+  });
+
+  it('excludes configured holidays from range totals', () => {
+    setHolidayCacheForTests(['2026-07-01']);
+    const minutes = calculateMarketMinutesInRange('2026-06-29', '2026-07-03');
+    expect(minutes).toBe(4 * FULL_TRADING_DAY_MINUTES);
+  });
+
+  it('throws when the start date is after the end date', () => {
+    expect(() => calculateMarketMinutesInRange('2026-07-03', '2026-06-29')).toThrow(
+      'Start date must be before or equal to end date'
+    );
+  });
+
+  it('marks weekends as non-trading days', () => {
+    const status = checkDateStatus('2026-07-05');
+    expect(status.isWeekend).toBe(true);
+    expect(status.isTradingDay).toBe(false);
+    expect(status.marketMinutes).toBe(0);
+  });
+
+  it('marks holidays as non-trading days', () => {
+    setHolidayCacheForTests(['2026-07-02']);
+    const status = checkDateStatus('2026-07-02');
+    expect(status.isHoliday).toBe(true);
+    expect(status.isTradingDay).toBe(false);
+    expect(status.marketMinutes).toBe(0);
+  });
+
+  it('returns remaining session minutes on expiry day', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(istInstant('2026-07-02', 10));
+
+    expect(calculateMarketMinutesTillExpiry('2026-07-02')).toBe(330);
+    expect(calculateMarketMinutesTillExpiry('02-JUL-2026')).toBe(330);
+  });
+
+  it('includes future trading days until expiry', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(istInstant('2026-07-02', 10));
+
+    expect(calculateMarketMinutesTillExpiry('2026-07-03')).toBe(330 + FULL_TRADING_DAY_MINUTES);
+  });
+
+  it('returns 0 for expiries before today', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(istInstant('2026-07-02', 10));
+
+    expect(calculateMarketMinutesTillExpiry('2026-07-01')).toBe(0);
+  });
+
+  it('returns full session minutes before market open on expiry day', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(istInstant('2026-07-02', 8));
+
+    expect(calculateMarketMinutesTillExpiry('2026-07-02')).toBe(FULL_TRADING_DAY_MINUTES);
+  });
+
+  it('returns 0 after market close on expiry day', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(istInstant('2026-07-02', 16));
+
+    expect(calculateMarketMinutesTillExpiry('2026-07-02')).toBe(0);
+  });
+});

--- a/server/lib/market-minutes.ts
+++ b/server/lib/market-minutes.ts
@@ -1,5 +1,4 @@
 import { TZDate } from '@date-fns/tz';
-import { db } from '@server/db';
 import { holidaysTable } from '@server/db/schema';
 import { logger } from '@server/lib/logger';
 import {
@@ -31,6 +30,7 @@ const MARKET_CLOSE_MINUTES = MARKET_CLOSE_HOUR * 60 + MARKET_CLOSE_MINUTE; // 93
 let holidayCache: Set<string> | null = null;
 
 export async function loadHolidayCache(): Promise<void> {
+  const { db } = await import('@server/db');
   const holidays = await db.select({ date: holidaysTable.date }).from(holidaysTable);
 
   holidayCache = new Set(holidays.map((h) => h.date));
@@ -39,6 +39,16 @@ export async function loadHolidayCache(): Promise<void> {
 
 export function isHolidayCacheLoaded(): boolean {
   return holidayCache !== null;
+}
+
+/** Test helper: seed holiday dates without hitting the database. */
+export function setHolidayCacheForTests(holidays: Iterable<string>): void {
+  holidayCache = new Set(holidays);
+}
+
+/** Test helper: reset holiday cache between tests. */
+export function clearHolidayCacheForTests(): void {
+  holidayCache = null;
 }
 
 function isHoliday(dateStr: string): boolean {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['server/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '@server': path.resolve(__dirname, './server'),
+      '@shared': path.resolve(__dirname, './server/shared'),
+      '@client': path.resolve(__dirname, './client/src'),
+    },
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Vitest-based unit test suite for core calculator logic and wires it into GitHub Actions alongside server and client typechecks.

## Tests added

- **Delta** (`server/lib/calculators/delta.test.ts`): ATM/deep ITM/OTM behavior, put-call parity, invalid input guards
- **Sigma** (`server/lib/calculators/sigma.test.ts`): σₙ, σₓ, σₓᵢ, SD, and asymmetric bounds
- **Returns** (`server/lib/calculators/returns.test.ts`): sell value, strike position, return %
- **Market minutes** (`server/lib/market-minutes.test.ts`): trading-day counting, holidays, expiry-day session math (with fake timers)

## Supporting changes

- Vitest config with `@server` / `@shared` path aliases
- `npm test` and `npm run test:watch` scripts
- `loadHolidayCache()` now lazy-imports the DB so pure calculator tests do not require env vars at import time
- Test-only holiday cache helpers: `setHolidayCacheForTests` / `clearHolidayCacheForTests`

## CI

New workflow at `.github/workflows/ci.yml` runs on push/PR to `main`:

1. `npm ci`
2. `npm run typecheck` (server)
3. `npm --prefix client run typecheck` (client)
4. `npm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f229e-5788-7b7b-916c-9fb9a9308484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f229e-5788-7b7b-916c-9fb9a9308484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

